### PR TITLE
Remove redundant copies (and some minor modifications)

### DIFF
--- a/include/ndarray.hpp
+++ b/include/ndarray.hpp
@@ -65,13 +65,13 @@ class NDArray {
   //==========================================================================
   // Constructors and Destructors
   NDArray();
-  NDArray(std::vector<size_t> init_shape, bool c_continuous = true);
-  NDArray(std::vector<T> data, std::vector<size_t> init_shape,
+  NDArray(const std::vector<size_t>& init_shape, bool c_continuous = true);
+  NDArray(const std::vector<T>& data, const std::vector<size_t>& init_shape,
           bool c_continuous = true);
   ~NDArray() = default;
 
   // Static load function
-  static NDArray load(std::string fname);
+  static NDArray load(const std::string& fname);
 
   //==========================================================================
   // Indexing
@@ -81,7 +81,7 @@ class NDArray {
   const T& operator()(const std::vector<size_t>& indices) const;
 
   // Variadic indexing operators
-  // Access data with array idicies.
+  // Access data with array indices.
   template <typename... INDS>
   T& operator()(INDS... inds);
   template <typename... INDS>
@@ -95,7 +95,7 @@ class NDArray {
   // Constant Methods
 
   // Return vector describing shape of array
-  std::vector<size_t> shape() const;
+  const std::vector<size_t>& shape() const;
 
   // Return number of elements in array
   size_t size() const;
@@ -110,20 +110,20 @@ class NDArray {
   bool c_continuous() const;
 
   // Save array to the file fname.npy
-  void save(std::string fname) const;
+  void save(const std::string& fname) const;
 
   //==========================================================================
   // Non-Constant Methods
 
   // Fills entire array with the value provided
-  void fill(T val);
+  void fill(const T& val);
 
   // Will reshape the array to the given dimensions
-  void reshape(std::vector<size_t> new_shape);
+  void reshape(const std::vector<size_t>& new_shape);
 
   // Realocates array to fit the new size.
   // DATA CAN BE LOST IF ARRAY IS SHRUNK
-  void reallocate(std::vector<size_t> new_shape);
+  void reallocate(const std::vector<size_t>& new_shape);
 
   //==========================================================================
   // Operators for Any Type (Same or Different)
@@ -139,13 +139,13 @@ class NDArray {
   //==========================================================================
   // Operators for Constants
   template <class C>
-  NDArray& operator+=(C c);
+  NDArray& operator+=(const C& c);
   template <class C>
-  NDArray& operator-=(C c);
+  NDArray& operator-=(const C& c);
   template <class C>
-  NDArray& operator*=(C c);
+  NDArray& operator*=(const C& c);
   template <class C>
-  NDArray& operator/=(C c);
+  NDArray& operator/=(const C& c);
 
   //==========================================================================
   // Conversion Operator
@@ -196,15 +196,15 @@ enum class DType {
 // array of chars, which must latter be type cast be the user. The char* to
 // the data is returned as a reference, along with the number of elements,
 // continuits, and element size in bytes. Returned is a vector for the shape.
-void load_npy(std::string fname, char*& data_ptr, std::vector<size_t>& shape,
+void load_npy(const std::string& fname, char*& data_ptr, std::vector<size_t>& shape,
               DType& dtype, bool& c_contiguous);
 
 // Function which writes binary data to a Numpy .npy file.
-void write_npy(std::string fname, const char* data_ptr,
-               std::vector<size_t> shape, DType dtype, bool c_contiguous);
+void write_npy(const std::string& fname, const char* data_ptr,
+               const std::vector<size_t>& shape, DType dtype, bool c_contiguous);
 
 // Returns the proper DType for a given Numpy dtype.descr string.
-DType descr_to_DType(std::string dtype);
+DType descr_to_DType(const std::string& dtype);
 
 // Returns Numpy descr string for given DType
 std::string DType_to_descr(DType dtype);
@@ -238,7 +238,7 @@ template <class T>
 NDArray<T>::NDArray():data_{}, shape_{}, c_continuous_{true}, dimensions_{0} {}
 
 template <class T>
-NDArray<T>::NDArray(std::vector<size_t> init_shape, bool c_continuous) {
+NDArray<T>::NDArray(const std::vector<size_t>& init_shape, bool c_continuous) {
   if (init_shape.size() > 0) {
     shape_ = init_shape;
     dimensions_ = shape_.size();
@@ -259,7 +259,7 @@ NDArray<T>::NDArray(std::vector<size_t> init_shape, bool c_continuous) {
 }
 
 template <class T>
-NDArray<T>::NDArray(std::vector<T> data, std::vector<size_t> init_shape,
+NDArray<T>::NDArray(const std::vector<T>& data, const std::vector<size_t>& init_shape,
                     bool c_continuous) {
   if (init_shape.size() > 0) {
     shape_ = init_shape;
@@ -288,7 +288,7 @@ NDArray<T>::NDArray(std::vector<T> data, std::vector<size_t> init_shape,
 }
 
 template <class T>
-NDArray<T> NDArray<T>::load(std::string fname) {
+NDArray<T> NDArray<T>::load(const std::string &fname) {
   // Get expected DType according to T
   DType expected_dtype;
   const char* T_type_name = typeid(T).name();
@@ -436,7 +436,7 @@ NDARRAY_INLINE const T& NDArray<T>::operator[](size_t i) const {
 }
 
 template <class T>
-NDARRAY_INLINE std::vector<size_t> NDArray<T>::shape() const {
+NDARRAY_INLINE const std::vector<size_t>& NDArray<T>::shape() const {
   return shape_;
 }
 
@@ -477,7 +477,7 @@ NDARRAY_INLINE bool NDArray<T>::c_continuous() const {
 }
 
 template <class T>
-void NDArray<T>::save(std::string fname) const {
+void NDArray<T>::save(const std::string& fname) const {
   // Get expected DType according to T
   DType dtype;
   const char* T_type_name = typeid(T).name();
@@ -517,12 +517,12 @@ void NDArray<T>::save(std::string fname) const {
 }
 
 template <class T>
-void NDArray<T>::fill(T val) {
+void NDArray<T>::fill(const T& val) {
   std::fill(data_.begin(), data_.end(), val);
 }
 
 template <class T>
-void NDArray<T>::reshape(std::vector<size_t> new_shape) {
+void NDArray<T>::reshape(const std::vector<size_t>& new_shape) {
   // Ensure new shape has proper dimensions
   if (new_shape.size() < 1) {
     std::string mssg =
@@ -549,7 +549,7 @@ void NDArray<T>::reshape(std::vector<size_t> new_shape) {
 }
 
 template <class T>
-void NDArray<T>::reallocate(std::vector<size_t> new_shape) {
+void NDArray<T>::reallocate(const std::vector<size_t>& new_shape) {
   // Ensure new shape has proper dimensions
   if (new_shape.size() < 1) {
     std::string mssg =
@@ -673,7 +673,7 @@ NDArray<T>& NDArray<T>::operator/=(const NDArray<C>& a) {
 
 template <class T>
 template <class C>
-NDArray<T>& NDArray<T>::operator+=(C c) {
+NDArray<T>& NDArray<T>::operator+=(const C& c) {
   // Do addition
   for (size_t i = 0; i < data_.size(); i++) {
     data_[i] += c;
@@ -684,7 +684,7 @@ NDArray<T>& NDArray<T>::operator+=(C c) {
 
 template <class T>
 template <class C>
-NDArray<T>& NDArray<T>::operator-=(C c) {
+NDArray<T>& NDArray<T>::operator-=(const C& c) {
   // Do subtraction
   for (size_t i = 0; i < data_.size(); i++) {
     data_[i] -= c;
@@ -695,7 +695,7 @@ NDArray<T>& NDArray<T>::operator-=(C c) {
 
 template <class T>
 template <class C>
-NDArray<T>& NDArray<T>::operator*=(C c) {
+NDArray<T>& NDArray<T>::operator*=(const C& c) {
   // Do multiplication
   for (size_t i = 0; i < data_.size(); i++) {
     data_[i] *= c;
@@ -706,7 +706,7 @@ NDArray<T>& NDArray<T>::operator*=(C c) {
 
 template <class T>
 template <class C>
-NDArray<T>& NDArray<T>::operator/=(C c) {
+NDArray<T>& NDArray<T>::operator/=(const C& c) {
   // Do division
   for (size_t i = 0; i < data_.size(); i++) {
     data_[i] /= c;
@@ -851,7 +851,7 @@ NDARRAY_INLINE size_t NDArray<T>::fortran_continuous_index(
 
 //==============================================================================
 // NPY Function Definitions
-inline void load_npy(std::string fname, char*& data_ptr,
+inline void load_npy(const std::string& fname, char*& data_ptr,
                      std::vector<size_t>& shape, DType& dtype,
                      bool& c_contiguous) {
   // Open file
@@ -993,8 +993,8 @@ inline void load_npy(std::string fname, char*& data_ptr,
   file.close();
 }
 
-inline void write_npy(std::string fname, const char* data_ptr,
-                      std::vector<size_t> shape, DType dtype,
+inline void write_npy(const std::string& fname, const char* data_ptr,
+                      const std::vector<size_t>& shape, DType dtype,
                       bool c_contiguous) {
   // Calculate number of elements from the shape
   size_t n_elements = shape[0];
@@ -1075,7 +1075,7 @@ inline void write_npy(std::string fname, const char* data_ptr,
   file.close();
 }
 
-inline DType descr_to_DType(std::string dtype) {
+inline DType descr_to_DType(const std::string& dtype) {
   if (dtype == "b1")
     return DType::CHAR;
   else if (dtype == "B1")

--- a/include/ndarray.hpp
+++ b/include/ndarray.hpp
@@ -855,7 +855,7 @@ inline void load_npy(std::string fname, char*& data_ptr,
                      std::vector<size_t>& shape, DType& dtype,
                      bool& c_contiguous) {
   // Open file
-  std::ifstream file(fname);
+  std::ifstream file(fname, std::ios::binary);
 
   // Read magic string
   char* magic_string = new char[6];

--- a/include/ndarray.hpp
+++ b/include/ndarray.hpp
@@ -102,6 +102,9 @@ class NDArray {
   //==========================================================================
   // Constant Methods
 
+  // Return underlying data vector
+  const std::vector<T>& data_vector() const;
+
   // Return vector describing shape of array
   const std::vector<size_t>& shape() const;
 
@@ -471,6 +474,11 @@ NDARRAY_INLINE T& NDArray<T>::operator[](size_t i) {
 template <class T>
 NDARRAY_INLINE const T& NDArray<T>::operator[](size_t i) const {
   return data_[i];
+}
+
+template <class T>
+NDARRAY_INLINE const std::vector<T>& NDArray<T>::data_vector() const {
+  return data_;
 }
 
 template <class T>


### PR DESCRIPTION
Hi! Thank you for sharing your handy and easy-to-employ library.
I looked into the code and found some lines that might be able to improve mainly in efficiency, so I am making this pull request.

My modifications are as follows.
1. `ifstream` instance may be better initialized with `std::ios::binary` mode.
   * This fix is similar to your commit 7fe5fb8.
2. Some pass-by-value function calls cause redundant copies.
3. We can cut more copies with a move constructor and a move assignment operator.
4. I wanted a member function of `NDArray` that returns the underlying vector container.
   * My use case is to load a .npy file that contains 1d time series data and to perform a customized moving window operation, so plain `std::vector` and your load and save functionality of `NDArray` suffice my requirements.

I am afraid I have not fully tested all of my modifications, and I just made a simple code and checked that memory usage reduces compared to the original code.
If you share me your test codes, then I will perform the tests to check my modifications.

Feel free to respond conservatively. Anyway I appreciate your work, and I am able to proceed my task with your library, so thanks again!

Lastly, I paste my simple code to check the memory usage, just for your infomation.
```
#include <string>
#include <vector>
#include <iostream>

#include "ndarray.hpp"

int main() {
    // CATION
    // This code writes a barren file of size 2GB to your disk!!

    const std::string npy_path("some_big_array.npy");
    {
        const unsigned dim1 = 1024;
        const unsigned dim2 = 1024;
        const unsigned dim3 = 500;
        const unsigned size = dim1 * dim2 * dim3;

        std::vector<float> data(size, 0);

        // constructor with copy for a large vector
        // NDArray<float> array1(data,  {dim1, dim2, dim3});

        // constructor with move semantics for a large vector
        NDArray<float> array1(std::move(data), {dim1, dim2, dim3});

        std::cout << "ndarray initialized:\n";
        for(unsigned i=0; i<10; i++){
            std::cout << array1[i] << std::endl;
        }

        array1.save(npy_path);
        std::cout << "ndarray saved" << std::endl;
    }

    // move constructor 
    NDArray<float> array2 = NDArray<float>::load(npy_path);

    // copy constructor
    // NDArray<float> array3(array2);

    std::cout << "ndarray loaded again:\n";
    for(unsigned i=0; i<10; i++){
        std::cout << array2[i] << std::endl;
    }

    return 0;
}
```